### PR TITLE
Native Calendar Integration

### DIFF
--- a/src/helpers/nativeCalendar.ts
+++ b/src/helpers/nativeCalendar.ts
@@ -14,7 +14,8 @@ async function getDefaultCalendarSource() {
             return null;
         }
         return defaultCalendars[0].source;
-    } catch (e: any) {
+    }
+ catch (e: any) {
         Alert.alert(e.toString());
         return null;
     }
@@ -62,7 +63,8 @@ async function addEventToCalendar(title: string, startDate: Date, endDate: Date,
             location,
             timeZone: 'GMT',
         });
-    } catch (e: any) {
+    }
+ catch (e: any) {
         Alert.alert(e.toString());
         return false;
     }

--- a/src/helpers/nativeCalendar.ts
+++ b/src/helpers/nativeCalendar.ts
@@ -46,7 +46,7 @@ async function addEventToCalendar(title: string, startDate: Date, endDate: Date,
 
     try {
         const calendarId = await Calendar.createCalendarAsync({
-            title: 'Expo Calendar',
+            title: 'Knight Connect',
             color: 'blue',
             entityType: Calendar.EntityTypes.EVENT,
             sourceId: defaultCalendarSource.id,

--- a/src/helpers/nativeCalendar.ts
+++ b/src/helpers/nativeCalendar.ts
@@ -42,7 +42,6 @@ async function addEventToCalendar(title: string, startDate: Date, endDate: Date,
 
     const defaultCalendarSource = await getDefaultCalendarSource();
     if (defaultCalendarSource === null) return false;
-    console.log(defaultCalendarSource);
 
     try {
         const calendarId = await Calendar.createCalendarAsync({

--- a/src/helpers/nativeCalendar.ts
+++ b/src/helpers/nativeCalendar.ts
@@ -1,0 +1,74 @@
+import * as Calendar from 'expo-calendar';
+import { Alert, Platform } from 'react-native';
+
+async function getDefaultCalendarSource() {
+    if (Platform.OS !== 'ios') {
+        return { isLocalAccount: true, name: 'Expo Calendar', type: 'local' };
+    }
+    try {
+        const calendars = await Calendar.getCalendarsAsync();
+        const defaultCalendars = calendars.filter(
+            each => each.allowsModifications && each.entityType === Calendar.EntityTypes.EVENT && each.source.name === 'iCloud');
+        if (defaultCalendars.length === 0) {
+            Alert.alert('No calendar available');
+            return null;
+        }
+        return defaultCalendars[0].source;
+    } catch (e: any) {
+        Alert.alert(e.toString());
+        return null;
+    }
+}
+
+async function grantPermissions() {
+    const { status: status1 } = await Calendar.requestCalendarPermissionsAsync();
+    if (status1 !== 'granted') {
+        Alert.alert('Calendar permission not granted');
+        return false;
+    }
+    const { status: status2 } = await Calendar.requestRemindersPermissionsAsync();
+    if (status2 !== 'granted') {
+        Alert.alert('Reminders permission not granted');
+        return false;
+    }
+    return true;
+}
+
+async function addEventToCalendar(title: string, startDate: Date, endDate: Date, location?: string) {
+    if (!(await grantPermissions())) {
+        Alert.alert('Calendar permission not granted');
+        return false;
+    }
+
+    const defaultCalendarSource = await getDefaultCalendarSource();
+    if (defaultCalendarSource === null) return false;
+    console.log(defaultCalendarSource);
+
+    try {
+        const calendarId = await Calendar.createCalendarAsync({
+            title: 'Expo Calendar',
+            color: 'blue',
+            entityType: Calendar.EntityTypes.EVENT,
+            sourceId: defaultCalendarSource.id,
+            source: defaultCalendarSource,
+            name: 'internalCalendarName',
+            ownerAccount: 'personal',
+            accessLevel: Calendar.CalendarAccessLevel.OWNER,
+        });
+
+        await Calendar.createEventAsync(calendarId, {
+            title,
+            startDate,
+            endDate,
+            location,
+            timeZone: 'GMT',
+        });
+    } catch (e: any) {
+        Alert.alert(e.toString());
+        return false;
+    }
+
+    return true;
+}
+
+export { addEventToCalendar };


### PR DESCRIPTION
This branch allows the app to add events on a system/native calendar. 
A new calendar "Knight Connect" will be added to the system calendar if the user allows. Then events can be added to the calendar. 
Details are handled automatically, to use add an event, call function `addEventToCalendar(title: string, startDate: Date, endDate: Date, location?: string)`. 

The function is tested on iOS, but not Android. 